### PR TITLE
Calypso parser + read more data on Navigo Pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added Opal parser (Sydney (and surrounds), NSW, Australia)
 - Added ITSO parser (United Kingdom)
 
-## v0.4
+## v0.4
 
 - Updated Navigo parser (Paris, France)
+  - Now use a global Calypso parser, with defined structures

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This is a list of metro cards and transit systems that need support or have part
 - **App Author**: [@luu176](https://github.com/luu176)
 - **Charliecard Parser**: [@zacharyweiss](https://github.com/zacharyweiss)
 - **Rav-Kav Parser**: [@luu176](https://github.com/luu176)
-- **Navigo Parser**: [@luu176](https://github.com/luu176) and [@DocSystem](https://github.com/DocSystem)
+- **Navigo Parser**: [@luu176](https://github.com/luu176), [@DocSystem](https://github.com/DocSystem)
 - **Metromoney Parser**: [@Leptopt1los](https://github.com/Leptopt1los)
 - **Bip! Parser**: [@rbasoalto](https://github.com/rbasoalto) [@gornekich](https://github.com/gornekich)
 - **Clipper Parser**: [@ke6jjj](https://github.com/ke6jjj)

--- a/api/calypso/calypso_util.c
+++ b/api/calypso/calypso_util.c
@@ -1,0 +1,247 @@
+#include <stdlib.h>
+#include <string.h>
+#include "calypso_util.h"
+
+CalypsoElement make_calypso_final_element(
+    const char* key,
+    int size,
+    const char* label,
+    CalypsoFinalType final_type) {
+    CalypsoElement final_element = {};
+
+    final_element.type = CALYPSO_ELEMENT_TYPE_FINAL;
+    final_element.final = malloc(sizeof(CalypsoFinalElement));
+    final_element.final->size = size;
+    final_element.final->final_type = final_type;
+    strncpy(final_element.final->key, key, 64);
+    strncpy(final_element.final->label, label, 64);
+
+    return final_element;
+}
+
+CalypsoElement make_calypso_bitmap_element(const char* key, int size, CalypsoElement* elements) {
+    CalypsoElement bitmap_element = {};
+
+    bitmap_element.type = CALYPSO_ELEMENT_TYPE_BITMAP;
+    bitmap_element.bitmap = malloc(sizeof(CalypsoBitmapElement));
+    bitmap_element.bitmap->size = size;
+    bitmap_element.bitmap->elements = malloc(size * sizeof(CalypsoElement));
+    for(int i = 0; i < size; i++) {
+        bitmap_element.bitmap->elements[i] = elements[i];
+    }
+    strncpy(bitmap_element.bitmap->key, key, 64);
+
+    return bitmap_element;
+}
+
+void free_calypso_element(CalypsoElement* element) {
+    if(element->type == CALYPSO_ELEMENT_TYPE_FINAL) {
+        free(element->final);
+    } else {
+        for(int i = 0; i < element->bitmap->size; i++) {
+            free_calypso_element(&element->bitmap->elements[i]);
+        }
+        free(element->bitmap->elements);
+        free(element->bitmap);
+    }
+}
+
+void free_calypso_structure(CalypsoApp* structure) {
+    for(int i = 0; i < structure->elements_size; i++) {
+        free_calypso_element(&structure->elements[i]);
+    }
+    free(structure->elements);
+    free(structure);
+}
+
+int* get_bit_positions(const char* binary_string, int* count) {
+    int length = strlen(binary_string);
+    int* positions = malloc(length * sizeof(int));
+    int pos_index = 0;
+
+    for(int i = 0; i < length; i++) {
+        if(binary_string[length - 1 - i] == '1') {
+            positions[pos_index++] = i;
+        }
+    }
+
+    *count = pos_index;
+    return positions;
+}
+
+int is_bit_present(int* positions, int count, int bit) {
+    for(int i = 0; i < count; i++) {
+        if(positions[i] == bit) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+bool is_calypso_subnode_present(
+    const char* binary_string,
+    const char* key,
+    CalypsoBitmapElement* bitmap) {
+    char bit_slice[bitmap->size + 1];
+    strncpy(bit_slice, binary_string, bitmap->size);
+    bit_slice[bitmap->size] = '\0';
+    int count = 0;
+    int* positions = get_bit_positions(bit_slice, &count);
+    int offset = bitmap->size;
+    for(int i = 0; i < count; i++) {
+        CalypsoElement* element = &bitmap->elements[positions[i]];
+        if(element->type == CALYPSO_ELEMENT_TYPE_FINAL) {
+            if(strcmp(element->final->key, key) == 0) {
+                return true;
+            }
+            offset += element->final->size;
+        } else {
+            if(strcmp(element->bitmap->key, key) == 0) {
+                return true;
+            }
+            int sub_binary_string_size = element->bitmap->size;
+            char bit_slice[sub_binary_string_size + 1];
+            strncpy(bit_slice, binary_string, sub_binary_string_size);
+            bit_slice[sub_binary_string_size] = '\0';
+            if(is_calypso_subnode_present(binary_string + offset, key, element->bitmap)) {
+                return true;
+            }
+            offset += element->bitmap->size;
+        }
+    }
+    return false;
+}
+
+bool is_calypso_node_present(const char* binary_string, const char* key, CalypsoApp* structure) {
+    int offset = 0;
+    for(int i = 0; i < structure->elements_size; i++) {
+        if(structure->elements[i].type == CALYPSO_ELEMENT_TYPE_FINAL) {
+            if(strcmp(structure->elements[i].final->key, key) == 0) {
+                return true;
+            }
+            offset += structure->elements[i].final->size;
+        } else {
+            if(strcmp(structure->elements[i].bitmap->key, key) == 0) {
+                return true;
+            }
+            int sub_binary_string_size = structure->elements[i].bitmap->size;
+            char bit_slice[sub_binary_string_size + 1];
+            strncpy(bit_slice, binary_string, sub_binary_string_size);
+            bit_slice[sub_binary_string_size] = '\0';
+            if(is_calypso_subnode_present(
+                   binary_string + offset, key, structure->elements[i].bitmap)) {
+                return true;
+            }
+            offset += structure->elements[i].bitmap->size;
+        }
+    }
+    return false;
+}
+
+int get_calypso_subnode_offset(
+    const char* binary_string,
+    const char* key,
+    CalypsoBitmapElement* bitmap,
+    bool* found) {
+    char bit_slice[bitmap->size + 1];
+    strncpy(bit_slice, binary_string, bitmap->size);
+    bit_slice[bitmap->size] = '\0';
+
+    int count = 0;
+    int* positions = get_bit_positions(bit_slice, &count);
+
+    int count_offset = bitmap->size;
+    for(int i = 0; i < count; i++) {
+        CalypsoElement element = bitmap->elements[positions[i]];
+        if(element.type == CALYPSO_ELEMENT_TYPE_FINAL) {
+            if(strcmp(element.final->key, key) == 0) {
+                *found = true;
+                free(positions);
+                return count_offset;
+            }
+            count_offset += element.final->size;
+        } else {
+            if(strcmp(element.bitmap->key, key) == 0) {
+                *found = true;
+                free(positions);
+                return count_offset;
+            }
+            count_offset += get_calypso_subnode_offset(
+                binary_string + count_offset, key, element.bitmap, found);
+            if(*found) {
+                free(positions);
+                return count_offset;
+            }
+        }
+    }
+    free(positions);
+    return count_offset;
+}
+
+int get_calypso_node_offset(const char* binary_string, const char* key, CalypsoApp* structure) {
+    int count = 0;
+    bool found = false;
+    for(int i = 0; i < structure->elements_size; i++) {
+        if(structure->elements[i].type == CALYPSO_ELEMENT_TYPE_FINAL) {
+            if(strcmp(structure->elements[i].final->key, key) == 0) {
+                return count;
+            }
+            count += structure->elements[i].final->size;
+        } else {
+            if(strcmp(structure->elements[i].bitmap->key, key) == 0) {
+                return count;
+            }
+            int sub_binary_string_size = structure->elements[i].bitmap->size;
+            char bit_slice[sub_binary_string_size + 1];
+            strncpy(bit_slice, binary_string + count, sub_binary_string_size);
+            bit_slice[sub_binary_string_size] = '\0';
+            count += get_calypso_subnode_offset(
+                binary_string + count, key, structure->elements[i].bitmap, &found);
+            if(found) {
+                return count;
+            }
+        }
+    }
+    return 0;
+}
+
+int get_calypso_subnode_size(const char* key, CalypsoElement* element) {
+    if(element->type == CALYPSO_ELEMENT_TYPE_FINAL) {
+        if(strcmp(element->final->key, key) == 0) {
+            return element->final->size;
+        }
+    } else {
+        if(strcmp(element->bitmap->key, key) == 0) {
+            return element->bitmap->size;
+        }
+        for(int i = 0; i < element->bitmap->size; i++) {
+            int size = get_calypso_subnode_size(key, &element->bitmap->elements[i]);
+            if(size != 0) {
+                return size;
+            }
+        }
+    }
+    return 0;
+}
+
+int get_calypso_node_size(const char* key, CalypsoApp* structure) {
+    for(int i = 0; i < structure->elements_size; i++) {
+        if(structure->elements[i].type == CALYPSO_ELEMENT_TYPE_FINAL) {
+            if(strcmp(structure->elements[i].final->key, key) == 0) {
+                return structure->elements[i].final->size;
+            }
+        } else {
+            if(strcmp(structure->elements[i].bitmap->key, key) == 0) {
+                return structure->elements[i].bitmap->size;
+            }
+            for(int j = 0; j < structure->elements[i].bitmap->size; j++) {
+                int size =
+                    get_calypso_subnode_size(key, &structure->elements[i].bitmap->elements[j]);
+                if(size != 0) {
+                    return size;
+                }
+            }
+        }
+    }
+    return 0;
+}

--- a/api/calypso/calypso_util.h
+++ b/api/calypso/calypso_util.h
@@ -1,0 +1,80 @@
+#include <stdbool.h>
+
+#ifndef CALYPSO_UTIL_H
+#define CALYPSO_UTIL_H
+
+typedef enum {
+    CALYPSO_APP_CONTRACT,
+} CalypsoAppType;
+
+typedef enum {
+    CALYPSO_FINAL_TYPE_UNKNOWN,
+    CALYPSO_FINAL_TYPE_NUMBER,
+    CALYPSO_FINAL_TYPE_DATE,
+    CALYPSO_FINAL_TYPE_TIME,
+    CALYPSO_FINAL_TYPE_PAY_METHOD,
+    CALYPSO_FINAL_TYPE_AMOUNT,
+    CALYPSO_FINAL_TYPE_SERVICE_PROVIDER,
+    CALYPSO_FINAL_TYPE_ZONES,
+    CALYPSO_FINAL_TYPE_TARIFF,
+    CALYPSO_FINAL_TYPE_NETWORK_ID,
+    CALYPSO_FINAL_TYPE_TRANSPORT_TYPE,
+    CALYPSO_FINAL_TYPE_CARD_STATUS,
+} CalypsoFinalType;
+
+typedef enum {
+    CALYPSO_ELEMENT_TYPE_BITMAP,
+    CALYPSO_ELEMENT_TYPE_FINAL
+} CalypsoElementType;
+
+typedef struct CalypsoFinalElement_t CalypsoFinalElement;
+typedef struct CalypsoBitmapElement_t CalypsoBitmapElement;
+
+typedef struct {
+    CalypsoElementType type;
+    union {
+        CalypsoFinalElement* final;
+        CalypsoBitmapElement* bitmap;
+    };
+} CalypsoElement;
+
+struct CalypsoFinalElement_t {
+    char key[64];
+    int size;
+    char label[64];
+    CalypsoFinalType final_type;
+};
+
+struct CalypsoBitmapElement_t {
+    char key[64];
+    int size;
+    CalypsoElement* elements;
+};
+
+typedef struct {
+    CalypsoAppType type;
+    CalypsoElement* elements;
+    int elements_size;
+} CalypsoApp;
+
+CalypsoElement make_calypso_final_element(
+    const char* key,
+    int size,
+    const char* label,
+    CalypsoFinalType final_type);
+
+CalypsoElement make_calypso_bitmap_element(const char* key, int size, CalypsoElement* elements);
+
+void free_calypso_structure(CalypsoApp* structure);
+
+int* get_bit_positions(const char* binary_string, int* count);
+
+int is_bit_present(int* positions, int count, int bit);
+
+bool is_calypso_node_present(const char* binary_string, const char* key, CalypsoApp* structure);
+
+int get_calypso_node_offset(const char* binary_string, const char* key, CalypsoApp* structure);
+
+int get_calypso_node_size(const char* key, CalypsoApp* structure);
+
+#endif // CALYPSO_UTIL_H

--- a/api/calypso/cards/navigo.c
+++ b/api/calypso/cards/navigo.c
@@ -1,0 +1,379 @@
+#include <stdlib.h>
+#include "navigo.h"
+
+CalypsoApp* get_navigo_contract_structure() {
+    CalypsoApp* NavigoContractStructure = malloc(sizeof(CalypsoApp));
+    if(!NavigoContractStructure) {
+        return NULL;
+    }
+
+    int app_elements_count = 1;
+
+    NavigoContractStructure->type = CALYPSO_APP_CONTRACT;
+    NavigoContractStructure->elements = malloc(app_elements_count * sizeof(CalypsoElement));
+    NavigoContractStructure->elements_size = app_elements_count;
+
+    NavigoContractStructure->elements[0] = make_calypso_bitmap_element(
+        "Contract",
+        20,
+        (CalypsoElement[]){
+            make_calypso_final_element(
+                "ContractNetworkId", 24, "Identification du réseau", CALYPSO_FINAL_TYPE_UNKNOWN),
+
+            make_calypso_final_element(
+                "ContractProvider",
+                8,
+                "Identification de l’exploitant",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "ContractTariff", 16, "Code tarif", CALYPSO_FINAL_TYPE_TARIFF),
+
+            make_calypso_final_element(
+                "ContractSerialNumber", 32, "Numéro TCN", CALYPSO_FINAL_TYPE_UNKNOWN),
+
+            make_calypso_bitmap_element(
+                "ContractCustomerInfoBitmap",
+                2,
+                (CalypsoElement[]){
+                    make_calypso_final_element(
+                        "ContractCustomerProfile",
+                        6,
+                        "Statut du titulaire ou Taux de réduction applicable",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractCustomerNumber",
+                        32,
+                        "Numéro de client",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                }),
+
+            make_calypso_bitmap_element(
+                "ContractPassengerInfoBitmap",
+                2,
+                (CalypsoElement[]){
+                    make_calypso_final_element(
+                        "ContractPassengerClass",
+                        8,
+                        "Classe de service des voyageurs",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractPassengerTotal",
+                        8,
+                        "Nombre total de voyageurs",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                }),
+
+            make_calypso_final_element(
+                "ContractVehicleClassAllowed",
+                6,
+                "Classes de véhicule autorisé",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+
+            make_calypso_final_element(
+                "ContractPaymentPointer",
+                32,
+                "Pointeurs sur les événements de paiement",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+
+            make_calypso_final_element(
+                "ContractPayMethod", 11, "Code mode de paiement", CALYPSO_FINAL_TYPE_PAY_METHOD),
+
+            make_calypso_final_element(
+                "ContractServices", 16, "Services autorisés", CALYPSO_FINAL_TYPE_UNKNOWN),
+
+            make_calypso_final_element(
+                "ContractPriceAmount", 16, "Montant total", CALYPSO_FINAL_TYPE_AMOUNT),
+
+            make_calypso_final_element(
+                "ContractPriceUnit", 16, "Code de monnaie", CALYPSO_FINAL_TYPE_UNKNOWN),
+
+            make_calypso_bitmap_element(
+                "ContractRestrictionBitmap",
+                7,
+                (CalypsoElement[]){
+                    make_calypso_final_element(
+                        "ContractRestrictStart", 11, "", CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractRestrictEnd", 11, "", CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractRestrictDay", 8, "", CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractRestrictTimeCode", 8, "", CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractRestrictCode",
+                        8,
+                        "Code de restriction",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractRestrictProduct",
+                        16,
+                        "Produit de restriction",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractRestrictLocation",
+                        16,
+                        "Référence du lieu de restriction",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                }),
+
+            make_calypso_bitmap_element(
+                "ContractValidityInfoBitmap",
+                9,
+                (CalypsoElement[]){
+                    make_calypso_final_element(
+                        "ContractValidityStartDate",
+                        14,
+                        "Date de début de validité",
+                        CALYPSO_FINAL_TYPE_DATE),
+                    make_calypso_final_element(
+                        "ContractValidityStartTime",
+                        11,
+                        "Heure de début de validité",
+                        CALYPSO_FINAL_TYPE_TIME),
+                    make_calypso_final_element(
+                        "ContractValidityEndDate",
+                        14,
+                        "Date de fin de validité",
+                        CALYPSO_FINAL_TYPE_DATE),
+                    make_calypso_final_element(
+                        "ContractValidityEndTime",
+                        11,
+                        "Heure de fin de validité",
+                        CALYPSO_FINAL_TYPE_TIME),
+                    make_calypso_final_element(
+                        "ContractValidityDuration",
+                        8,
+                        "Durée de validité",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractValidityLimiteDate",
+                        14,
+                        "Date limite de première utilisation",
+                        CALYPSO_FINAL_TYPE_DATE),
+                    make_calypso_final_element(
+                        "ContractValidityZones",
+                        8,
+                        "Numéros des zones autorisées",
+                        CALYPSO_FINAL_TYPE_ZONES),
+                    make_calypso_final_element(
+                        "ContractValidityJourneys",
+                        16,
+                        "Nombre de voyages autorisés",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractPeriodJourneys",
+                        16,
+                        "Nombre de voyages autorisés par période",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                }),
+
+            make_calypso_bitmap_element(
+                "ContractJourneyData",
+                8,
+                (CalypsoElement[]){
+                    make_calypso_final_element(
+                        "ContractJourneyOrigin",
+                        16,
+                        "Code lieu d’origine",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractJourneyDestination",
+                        16,
+                        "Code lieu de destination",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractJourneyRouteNumbers",
+                        16,
+                        "Numéros des lignes autorisées",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractJourneyRouteVariants",
+                        8,
+                        "Variantes aux numéros des lignes autorisées",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractJourneyRun", 16, "Référence du voyage", CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractJourneyVia", 16, "Code lieu du via", CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractJourneyDistance", 16, "Distance", CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "ContractJourneyInterchanges",
+                        8,
+                        "Nombre de correspondances autorisées",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                }),
+
+            make_calypso_bitmap_element(
+                "ContractSaleData",
+                4,
+                (CalypsoElement[]){
+                    make_calypso_final_element(
+                        "ContractValiditySaleDate", 14, "Date de vente", CALYPSO_FINAL_TYPE_DATE),
+                    make_calypso_final_element(
+                        "ContractValiditySaleTime", 11, "Heure de vente", CALYPSO_FINAL_TYPE_TIME),
+                    make_calypso_final_element(
+                        "ContractValiditySaleAgent",
+                        8,
+                        "Identification de l’exploitant de vente",
+                        CALYPSO_FINAL_TYPE_SERVICE_PROVIDER),
+                    make_calypso_final_element(
+                        "ContractValiditySaleDevice",
+                        16,
+                        "Identification du terminal de vente",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                }),
+
+            make_calypso_final_element(
+                "ContractStatus", 8, "État du contrat", CALYPSO_FINAL_TYPE_UNKNOWN),
+
+            make_calypso_final_element(
+                "ContractLoyaltyPoints",
+                16,
+                "Nombre de points de fidélité",
+                CALYPSO_FINAL_TYPE_NUMBER),
+
+            make_calypso_final_element(
+                "ContractAuthenticator",
+                16,
+                "Code de contrôle de l’intégrité des données",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+
+            make_calypso_final_element(
+                "ContractData(0..255)", 0, "Données complémentaires", CALYPSO_FINAL_TYPE_UNKNOWN),
+        });
+
+    return NavigoContractStructure;
+}
+
+CalypsoApp* get_navigo_event_structure() {
+    CalypsoApp* NavigoEventStructure = malloc(sizeof(CalypsoApp));
+    if(!NavigoEventStructure) {
+        return NULL;
+    }
+
+    int app_elements_count = 3;
+
+    NavigoEventStructure->type = CALYPSO_APP_CONTRACT;
+    NavigoEventStructure->elements = malloc(app_elements_count * sizeof(CalypsoElement));
+    NavigoEventStructure->elements_size = app_elements_count;
+
+    NavigoEventStructure->elements[0] = make_calypso_final_element(
+        "EventDateStamp", 14, "Date de l’événement", CALYPSO_FINAL_TYPE_DATE);
+
+    NavigoEventStructure->elements[1] = make_calypso_final_element(
+        "EventTimeStamp", 11, "Heure de l’événement", CALYPSO_FINAL_TYPE_TIME);
+
+    NavigoEventStructure->elements[2] = make_calypso_bitmap_element(
+        "EventBitmap",
+        28,
+        (CalypsoElement[]){
+            make_calypso_final_element(
+                "EventDisplayData", 8, "Données pour l’affichage", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element("EventNetworkId", 24, "Réseau", CALYPSO_FINAL_TYPE_NUMBER),
+            make_calypso_final_element(
+                "EventCode", 8, "Nature de l’événement", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventResult", 8, "Code Résultat", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventServiceProvider",
+                8,
+                "Identité de l’exploitant",
+                CALYPSO_FINAL_TYPE_SERVICE_PROVIDER),
+            make_calypso_final_element(
+                "EventNotokCounter", 8, "Compteur événements anormaux", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventSerialNumber",
+                24,
+                "Numéro de série de l’événement",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventDestination", 16, "Destination de l’usager", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventLocationId", 16, "Lieu de l’événement", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventLocationGate", 8, "Identification du passage", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventDevice", 16, "Identificateur de l’équipement", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventRouteNumber", 16, "Référence de la ligne", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventRouteVariant",
+                8,
+                "Référence d’une variante de la ligne",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventJourneyRun", 16, "Référence de la mission", CALYPSO_FINAL_TYPE_NUMBER),
+            make_calypso_final_element(
+                "EventVehicleId", 16, "Identificateur du véhicule", CALYPSO_FINAL_TYPE_NUMBER),
+            make_calypso_final_element(
+                "EventVehicleClass", 8, "Type de véhicule utilisé", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventLocationType",
+                5,
+                "Type d’endroit (gare, arrêt de bus), ",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventEmployee", 240, "Code de l’employé impliqué", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventLocationReference",
+                16,
+                "Référence du lieu de l’événement",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventJourneyInterchanges",
+                8,
+                "Nombre de correspondances",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventPeriodJourneys", 16, "Nombre de voyage effectué", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventTotalJourneys",
+                16,
+                "Nombre total de voyage autorisé",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventJourneyDistance", 16, "Distance parcourue", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventPriceAmount",
+                16,
+                "Montant en jeu lors de l’événement",
+                CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventPriceUnit", 16, "Unité de montant en jeu", CALYPSO_FINAL_TYPE_UNKNOWN),
+            make_calypso_final_element(
+                "EventContractPointer",
+                5,
+                "Référence du contrat concerné",
+                CALYPSO_FINAL_TYPE_NUMBER),
+            make_calypso_final_element(
+                "EventAuthenticator", 16, "Code de sécurité", CALYPSO_FINAL_TYPE_UNKNOWN),
+
+            make_calypso_bitmap_element(
+                "EventData",
+                5,
+                (CalypsoElement[]){
+                    make_calypso_final_element(
+                        "EventDataDateFirstStamp",
+                        14,
+                        "Date de la première montée",
+                        CALYPSO_FINAL_TYPE_DATE),
+                    make_calypso_final_element(
+                        "EventDataTimeFirstStamp",
+                        11,
+                        "Heure de la première montée",
+                        CALYPSO_FINAL_TYPE_TIME),
+                    make_calypso_final_element(
+                        "EventDataSimulation",
+                        1,
+                        "Dernière validation (0=normal, 1=dégradé), ",
+                        CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "EventDataTrip", 2, "Tronçon", CALYPSO_FINAL_TYPE_UNKNOWN),
+                    make_calypso_final_element(
+                        "EventDataRouteDirection", 2, "Sens", CALYPSO_FINAL_TYPE_UNKNOWN),
+                }),
+        });
+
+    return NavigoEventStructure;
+}

--- a/api/calypso/cards/navigo.h
+++ b/api/calypso/cards/navigo.h
@@ -1,0 +1,10 @@
+#include "../calypso_util.h"
+
+#ifndef NAVIGO_STRUCTURES_H
+#define NAVIGO_STRUCTURES_H
+
+CalypsoApp* get_navigo_contract_structure();
+
+CalypsoApp* get_navigo_event_structure();
+
+#endif // NAVIGO_STRUCTURES_H

--- a/application.fam
+++ b/application.fam
@@ -5,7 +5,7 @@ App(
     entry_point="metroflip",
     stack_size=2 * 1024,
     fap_category="NFC",
-    fap_version="0.4.1",
+    fap_version="0.4",
     fap_icon="icon.png",
     fap_description="An implementation of metrodroid on the flipper",
     fap_author="luu176",

--- a/application.fam
+++ b/application.fam
@@ -5,7 +5,7 @@ App(
     entry_point="metroflip",
     stack_size=2 * 1024,
     fap_category="NFC",
-    fap_version="0.3.1",
+    fap_version="0.4.1",
     fap_icon="icon.png",
     fap_description="An implementation of metrodroid on the flipper",
     fap_author="luu176",

--- a/scenes/navigo.h
+++ b/scenes/navigo.h
@@ -1,6 +1,8 @@
 #include "../metroflip_i.h"
-#include <stdbool.h>
+#include "../api/calypso/calypso_util.h"
+#include "../api/calypso/cards/navigo.h"
 #include <datetime.h>
+#include <stdbool.h>
 
 #ifndef METRO_LIST_H
 #define METRO_LIST_H
@@ -42,14 +44,36 @@ typedef struct {
 } NavigoCardEnv;
 
 typedef struct {
-    float balance;
-    DateTime start_dt;
+    int card_status;
+    int commercial_id;
+} NavigoCardHolder;
+
+typedef struct {
+    int tariff;
+    int serial_number;
+    bool serial_number_available;
+    int pay_method;
+    bool pay_method_available;
+    double price_amount;
+    bool price_amount_available;
+    DateTime start_date;
+    DateTime end_date;
+    bool end_date_available;
+    int zones[5];
+    bool zones_available;
+    DateTime sale_date;
+    int sale_agent;
+    int sale_device;
+    int status;
+    int authenticator;
 } NavigoCardContract;
 
 typedef struct {
     NavigoCardEnv environment;
+    NavigoCardHolder holder;
     NavigoCardContract* contracts;
     NavigoCardEvent* events;
+    int ticket_count;
 } NavigoCardData;
 
 typedef struct {
@@ -59,13 +83,6 @@ typedef struct {
     // mutex
     FuriMutex* mutex;
 } NavigoContext;
-
-/* // Navigo Card Subscriptions Types
-static const char* SUBSCRIPTIONS_LIST[] = {
-    [1] = "Navigo decouverte",
-    [2] = "Navigo standard",
-    [6] = " Navigo integral",
-    [14] = "Imagine R (etudiant)"}; */
 
 // Service Providers
 static const char* SERVICE_PROVIDERS[] = {
@@ -93,6 +110,14 @@ typedef enum {
     TRAIN = 5,
     PARKING = 8
 } TRANSPORT_TYPE;
+
+typedef enum {
+    NAVIGO_EASY = 0,
+    NAVIGO_DECOUVERTE = 1,
+    NAVIGO_STANDARD = 2,
+    NAVIGO_INTEGRAL = 6,
+    IMAGINE_R = 14
+} CARD_STATUS;
 
 // Transition Types
 static const char* TRANSITION_LIST[] = {


### PR DESCRIPTION
## Global Calypso Support
- Add global Calypso reading functions/structures - see `api/calypso/calypso_util.c/h`

## Navigo-specific
- Add Navigo Event and Contract structures (taken from [pssi](https://github.com/Eric-Bourry/pssi/blob/master/pssi/plugins/navigo/structures.py)) - see `api/calypso/cards/navigo.c`
- Use the new parser on Navigo Events
- Read contract infos (using the new parser) from the pass and show them on the contract page

### Some smaller UI updates on Navigo
- Add more service providers (used on ContractSaleAgent)
- Add Navigo card type, contract type and payment method parsers
- Small improvements on events pages (show more information)
- Add vibration when Flipper reads the card (like on system NFC app)
- Remove some useless logs

## Known issues
- Some memory leaks are occuring, probably caused by bad context memory management (will fix that ASAP)