### PR TITLE
Add card number parsing + some UI/parsing tweaks

### DIFF
--- a/scenes/navigo_structs.h
+++ b/scenes/navigo_structs.h
@@ -63,6 +63,7 @@ typedef struct {
     NavigoCardContract contracts[2];
     NavigoCardEvent events[3];
     int ticket_counts[2];
+    unsigned int card_number;
 } NavigoCardData;
 
 typedef struct {


### PR DESCRIPTION
- Added card number parsing (from ICC Calypso app)
- Better zone parsing (for example "All zones (1-5)" instead of "Zones: 1, 2, 3, 4, 5" / "Zones 1-3" instead of "Zones: 1, 2, 3")
- Parse card environment app version
  - 6 bits integer
  - first 3 bits are for Intercode version (000 for v1 and 001 for v2)
  - last 3 bits are for Intercode subversion
- Show used contract type on events page (instead of showing "Contract: 2", it will now show "Contract: 2 (Imagine R Etudiant)")
- Temporary fix for Contract Sale Agent: removed the check to see if the value is present, caused by a bug with the `is_calypso_node_present` function, returning false even when the value is present.