### PR TITLE
Navigo Parser Updates

### DIFF
--- a/scenes/metroflip_scene_navigo.c
+++ b/scenes/metroflip_scene_navigo.c
@@ -91,8 +91,8 @@ const char* get_country(int country_num) {
 const char* get_network(int country_num, int network_num) {
     switch(country_num) {
     case 250:
-    switch(network_num) {
-    case 901:
+        switch(network_num) {
+        case 901:
             return "IDFM";
         default:
             return "Unknown";
@@ -243,7 +243,7 @@ const char* get_tariff(int tariff) {
         snprintf(tariff_str, 6, "%d", tariff);
         return tariff_str;
     }
-}
+    }
 }
 
 bool is_ticket_count_available(int tariff) {
@@ -368,6 +368,21 @@ const char* get_train_station(int station_group_id, int station_id) {
     return station;
 }
 
+const char* get_tram_line(int route_number) {
+    switch(route_number) {
+    case 16:
+        return "T6";
+    default: {
+        char* line = malloc(3 * sizeof(char));
+        if(!line) {
+            return "Unknown";
+        }
+        snprintf(line, 3, "T%d", route_number);
+        return line;
+    }
+    }
+}
+
 void show_event_info(
     NavigoCardEvent* event,
     NavigoCardContract* contracts,
@@ -384,6 +399,13 @@ void show_event_info(
                     parsed_data,
                     "%s 3 bis\n%s\n",
                     get_transport_type(event->transport_type),
+                    get_transition_type(event->transition));
+            } else if(event->transport_type == TRAM) {
+                furi_string_cat_printf(
+                    parsed_data,
+                    "%s %s\n%s\n",
+                    get_transport_type(event->transport_type),
+                    get_tram_line(event->route_number),
                     get_transition_type(event->transition));
             } else {
                 furi_string_cat_printf(

--- a/scenes/metroflip_scene_navigo.c
+++ b/scenes/metroflip_scene_navigo.c
@@ -78,15 +78,32 @@ const char* get_country(int country_num) {
     switch(country_num) {
     case 250:
         return "France";
-    default:
-        return "Unknown";
+    case 124:
+        return "Canada";
+    default: {
+        char* country = malloc(4 * sizeof(char));
+        snprintf(country, 4, "%d", country_num);
+        return country;
+    }
     }
 }
 
-const char* get_network(int network_num) {
+const char* get_network(int country_num, int network_num) {
+    switch(country_num) {
+    case 250:
     switch(network_num) {
     case 901:
-        return "Ile-de-France Mobilites";
+            return "IDFM";
+        default:
+            return "Unknown";
+        }
+    case 124:
+        switch(network_num) {
+        case 1:
+            return "STM";
+        default:
+            return "Unknown";
+        }
     default:
         return "Unknown";
     }
@@ -506,16 +523,11 @@ void show_environment_info(NavigoCardEnv* environment, FuriString* parsed_data) 
         "App Version: %s - v%d\n",
         get_intercode_version(environment->app_version),
         get_intercode_subversion(environment->app_version));
-    if(environment->country_num == 250) {
-        furi_string_cat_printf(parsed_data, "Country: France\n");
-    } else {
-        furi_string_cat_printf(parsed_data, "Country: %d\n", environment->country_num);
-    }
-    if(environment->network_num == 901) {
-        furi_string_cat_printf(parsed_data, "Network: Ile-de-France Mobilites\n");
-    } else {
-        furi_string_cat_printf(parsed_data, "Network: %d\n", environment->network_num);
-    }
+    furi_string_cat_printf(parsed_data, "Country: %s\n", get_country(environment->country_num));
+    furi_string_cat_printf(
+        parsed_data,
+        "Network: %s\n",
+        get_network(environment->country_num, environment->network_num));
     furi_string_cat_printf(parsed_data, "End of validity:\n");
     locale_format_datetime_cat(parsed_data, &environment->end_dt, false);
     furi_string_cat_printf(parsed_data, "\n");

--- a/scenes/navigo_structs.h
+++ b/scenes/navigo_structs.h
@@ -38,6 +38,12 @@ typedef struct {
 } NavigoCardHolder;
 
 typedef struct {
+    int count;
+    int relative_first_stamp_15mn;
+    int struct_number;
+} NavigoCardContractCounter;
+
+typedef struct {
     int tariff;
     int serial_number;
     bool serial_number_available;
@@ -55,6 +61,8 @@ typedef struct {
     int sale_device;
     int status;
     int authenticator;
+    NavigoCardContractCounter counter;
+    bool present;
 } NavigoCardContract;
 
 typedef struct {
@@ -62,7 +70,6 @@ typedef struct {
     NavigoCardHolder holder;
     NavigoCardContract contracts[2];
     NavigoCardEvent events[3];
-    int ticket_counts[2];
     unsigned int card_number;
 } NavigoCardData;
 


### PR DESCRIPTION
- Update Country/Network Parsing (basically use the functions)
  - Can be used in the future to automatically parse which Calypso structure to use
- Update Contract/Counter structure based on IDF Mobilités app Navigo Card parser
- Add tram `route_number` parser