### PR TITLE
Icon Rework

### DIFF
--- a/api/metroflip/metroflip_api.h
+++ b/api/metroflip/metroflip_api.h
@@ -132,6 +132,10 @@ void show_ravkav_event_info(RavKavCardEvent* event, FuriString* parsed_data);
 void show_ravkav_contract_info(RavKavCardContract* contract, FuriString* parsed_data);
 
 void show_ravkav_environment_info(RavKavCardEnv* environment, FuriString* parsed_data);
+
+extern const Icon I_RFIDDolphinReceive_97x61;
+extern const Icon I_icon;
+
 /*******************/
 #ifdef __cplusplus
 }

--- a/api/metroflip/metroflip_api_table_i.h
+++ b/api/metroflip/metroflip_api_table_i.h
@@ -68,4 +68,7 @@ static constexpr auto metroflip_api_table = sort(create_array_t<sym_entry>(
     API_METHOD(get_ravkav_env_holder_structure, CalypsoApp*, ()),
     API_METHOD(show_ravkav_event_info, void, (RavKavCardEvent*, FuriString*)),
     API_METHOD(show_ravkav_contract_info, void, (RavKavCardContract*, FuriString*)),
-    API_METHOD(show_ravkav_environment_info, void, (RavKavCardEnv*, FuriString*))));
+    API_METHOD(show_ravkav_environment_info, void, (RavKavCardEnv*, FuriString*)),
+    
+    API_VARIABLE(I_RFIDDolphinReceive_97x61, Icon),
+    API_VARIABLE(I_icon,Icon)));

--- a/metroflip_i.h
+++ b/metroflip_i.h
@@ -9,11 +9,6 @@
 #include <gui/view_dispatcher.h>
 #include <gui/scene_manager.h>
 #include "api/nfc/mf_classic_key_cache.h"
-#if __has_include(<assets_icons.h>)
-#include <assets_icons.h>
-#else
-extern const Icon I_RFIDDolphinReceive_97x61;
-#endif
 #include <flipper_application/plugins/composite_resolver.h>
 #include <loader/firmware_api/firmware_api.h>
 #include <flipper_application/plugins/plugin_manager.h>

--- a/scenes/metroflip_scene_load.c
+++ b/scenes/metroflip_scene_load.c
@@ -18,7 +18,7 @@ void metroflip_scene_load_on_enter(void* context) {
     DialogsFileBrowserOptions browser_options;
     Storage* storage = furi_record_open(RECORD_STORAGE);
     storage_simply_mkdir(storage, STORAGE_APP_DATA_PATH_PREFIX);
-    dialog_file_browser_set_basic_options(&browser_options, METROFLIP_FILE_EXTENSION, NULL);
+    dialog_file_browser_set_basic_options(&browser_options, METROFLIP_FILE_EXTENSION, &I_icon);
     browser_options.base_path = STORAGE_APP_DATA_PATH_PREFIX;
     FuriString* file_path = furi_string_alloc_set(browser_options.base_path);
 

--- a/scenes/metroflip_scene_parse.c
+++ b/scenes/metroflip_scene_parse.c
@@ -1,6 +1,7 @@
 #include "../metroflip_i.h"
 #include <furi.h>
 #include "../metroflip_plugins.h"
+#include "../api/metroflip/metroflip_api.h"
 #define TAG "Metroflip:Scene:Parse"
 #include <stdio.h>
 


### PR DESCRIPTION
Use internal icons and add them to the api. Now when you have .metro file in the apps_data/metroflip folder it will have the same icon as the app has