### PR TITLE
Fix Bugs Introduced by Load

### DIFF
--- a/scenes/metroflip_scene_load.c
+++ b/scenes/metroflip_scene_load.c
@@ -42,7 +42,6 @@ void metroflip_scene_load_on_enter(void* context) {
         scene_manager_next_scene(app->scene_manager, MetroflipSceneStart);
     }
     furi_string_free(file_path);
-    furi_string_free(card_type);
     furi_record_close(RECORD_STORAGE);
 }
 

--- a/scenes/metroflip_scene_parse.c
+++ b/scenes/metroflip_scene_parse.c
@@ -64,4 +64,5 @@ void metroflip_scene_parse_on_exit(void* context) {
         composite_api_resolver_free(app->resolver);
     }
     app->card_type = "unknown";
+    app->data_loaded = false;
 }

--- a/scenes/plugins/bip.c
+++ b/scenes/plugins/bip.c
@@ -385,7 +385,7 @@ static bool bip_on_event(Metroflip* app, SceneManagerEvent event) {
 static void bip_on_exit(Metroflip* app) {
     widget_reset(app->widget);
 
-    if(app->poller) {
+    if(app->poller && !app->data_loaded) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }

--- a/scenes/plugins/calypso.c
+++ b/scenes/plugins/calypso.c
@@ -2484,7 +2484,7 @@ static bool calypso_on_event(Metroflip* app, SceneManagerEvent event) {
 }
 
 static void calypso_on_exit(Metroflip* app) {
-    if(app->poller) {
+    if(app->poller && !app->data_loaded) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }

--- a/scenes/plugins/charliecard.c
+++ b/scenes/plugins/charliecard.c
@@ -1298,7 +1298,7 @@ static bool charliecard_on_event(Metroflip* app, SceneManagerEvent event) {
 static void charliecard_on_exit(Metroflip* app) {
     widget_reset(app->widget);
 
-    if(app->poller) {
+    if(app->poller && !app->data_loaded) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }

--- a/scenes/plugins/clipper.c
+++ b/scenes/plugins/clipper.c
@@ -651,7 +651,7 @@ static void clipper_on_exit(Metroflip* app) {
     widget_reset(app->widget);
     metroflip_app_blink_stop(app);
 
-    if(app->poller) {
+    if(app->poller && !app->data_loaded) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }

--- a/scenes/plugins/itso.c
+++ b/scenes/plugins/itso.c
@@ -197,7 +197,7 @@ static bool itso_on_event(Metroflip* app, SceneManagerEvent event) {
 static void itso_on_exit(Metroflip* app) {
     widget_reset(app->widget);
     metroflip_app_blink_stop(app);
-    if(app->poller) {
+    if(app->poller && !app->data_loaded) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }

--- a/scenes/plugins/metromoney.c
+++ b/scenes/plugins/metromoney.c
@@ -188,7 +188,7 @@ static bool metromoney_on_event(Metroflip* app, SceneManagerEvent event) {
 static void metromoney_on_exit(Metroflip* app) {
     widget_reset(app->widget);
 
-    if(app->poller) {
+    if(app->poller && !app->data_loaded) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }

--- a/scenes/plugins/myki.c
+++ b/scenes/plugins/myki.c
@@ -180,7 +180,7 @@ static bool myki_on_event(Metroflip* app, SceneManagerEvent event) {
 static void myki_on_exit(Metroflip* app) {
     widget_reset(app->widget);
     metroflip_app_blink_stop(app);
-    if(app->poller) {
+    if(app->poller && !app->data_loaded) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }

--- a/scenes/plugins/opal.c
+++ b/scenes/plugins/opal.c
@@ -301,7 +301,7 @@ static bool opal_on_event(Metroflip* app, SceneManagerEvent event) {
 static void opal_on_exit(Metroflip* app) {
     widget_reset(app->widget);
     metroflip_app_blink_stop(app);
-    if(app->poller) {
+    if(app->poller && !app->data_loaded) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }

--- a/scenes/plugins/smartrider.c
+++ b/scenes/plugins/smartrider.c
@@ -384,7 +384,7 @@ static bool smartrider_on_event(Metroflip* app, SceneManagerEvent event) {
 static void smartrider_on_exit(Metroflip* app) {
     widget_reset(app->widget);
 
-    if(app->poller) {
+    if(app->poller && !app->data_loaded) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }

--- a/scenes/plugins/troika.c
+++ b/scenes/plugins/troika.c
@@ -285,7 +285,7 @@ static bool troika_on_event(Metroflip* app, SceneManagerEvent event) {
 static void troika_on_exit(Metroflip* app) {
     widget_reset(app->widget);
 
-    if(app->poller) {
+    if(app->poller && !app->data_loaded) {
         nfc_poller_stop(app->poller);
         nfc_poller_free(app->poller);
     }


### PR DESCRIPTION
A few issues might arise from the load scene. 

1. We need to reset `app->data_loaded` to `false` after parsing is done. 
2. The card name furi string can't be free as it would result in the assignment to `app->card_type` getting lost. It that happens a lot of conditional check in `_scene_parse.c` will not work.
3. Only stop and free `app->poller` if poller and if the data was not loaded (i.e. when the user is reading from card). Only checking app->poller doesn't work if the user read a card first and then load from file. I'm not sure the reason why but I can consistently replicate this bug on my branch. So I added that condition in the check before trying to stop and free the poller.