### PR TITLE
Minor Updates to `suica.c` and `desfire.c`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Run the following commands in order to build the app:
 ```ufbt fap_metroflip```
 
 6. **Connect Your Flipper Zero**  
-Ensure your Flipper Zero is connected via USB and close the QFlipper application (if it’s open).  
+Ensure your Flipper Zero is connected via USB and close the qFlipper application (if it’s open).  
 
 7. **Launch the Build**  
 Run the final command to launch the app on your flipper:  
@@ -79,7 +79,7 @@ This is a list of metro cards and transit systems that need support or have part
 | **Opal**           | 🇦🇺 Sydney (and surrounds), NSW, Australia    | MIFARE DESFire    |
 | **Opus**           | 🇨🇦 Montreal, QC, Canada                      | Calypso           |
 | **Rav-Kav**        | 🇮🇱 Israel                                    | Calypso           |
-| **RENFE**          | 🇪🇸 Spain                                      | MIFARE Classic   |
+| **RENFE**          | 🇪🇸 Spain                                     | MIFARE Classic    |
 | **SmartRider**     | 🇦🇺 Perth, WA, Australia                      | MIFARE Classic    |
 | **Suica**          | 🇯🇵 Japan                                     | FeliCa            |
 | **Troika**         | 🇷🇺 Moscow, Russia                            | MIFARE Classic    |
@@ -91,7 +91,7 @@ This is a list of metro cards and transit systems that need support or have part
 - **App Author:** [@luu176](https://github.com/luu176)
 - **Info Slaves:** [@equipter](https://github.com/equipter), [@TheDingo8MyBaby](https://github.com/thedingo8mybaby), [@ry4000](https://github.com/ry4000), [@WillyJL](https://github.com/WillyJL)
 - **Bip! Parser:** [@rbasoalto](https://github.com/rbasoalto), [@gornekich](https://github.com/gornekich)
-- **Charliecard Parser:** [@ZacharyWeiss](https://github.com/zacharyweiss)
+- **Charliecard Parser:** [@zacharyweiss](https://github.com/zacharyweiss)
 - **Clipper Parser:** [@ke6jjj](https://github.com/ke6jjj)
 - **ITSO Parser:** [@gsp8181](https://github.com/gsp8181), [@hedger](https://github.com/hedger), [@gornekich](https://github.com/gornekich)
 - **Metromoney Parser:** [@Leptopt1los](https://github.com/Leptopt1los)
@@ -101,7 +101,7 @@ This is a list of metro cards and transit systems that need support or have part
 - **Opus Parser:** [@DocSystem](https://github.com/docsystem)
 - **Rav-Kav Parser:** [@luu176](https://github.com/luu176)
 - **RENFE Parser:** [@BocamoCM](https://github.com/BocamoCM)
-- **Suica Parser:** [@ZinongLi](https://github.com/zinongli)
+- **Suica Parser:** [@zinongli](https://github.com/zinongli)
 - **Troika Parser:** [@gornekich](https://github.com/gornekich)
 
 ---

--- a/scenes/desfire.c
+++ b/scenes/desfire.c
@@ -19,9 +19,9 @@ typedef struct {
     bool locked;
 } TransitCardInfo;
 
-TransitCardInfo cards[81] = {
+TransitCardInfo cards[82] = {
     {0x000001, "TTP (MAD)", "CRTM", true},
-    {0x0011F2, "myki", "myki (MEL)", false},
+    {0x0011F2, "myki", "TV", false},
     {0x002000, "Presto (YYZ)", "Metrolinx", true},
     {0x004048, "Mi Movilidad (GDL)", "SITEUR", true},
     {0x004055, "AT HOP (AKL)", "Auckland Transport", true},
@@ -53,6 +53,7 @@ TransitCardInfo cards[81] = {
     {0x314553, "opal", "Opal", false},
     {0x315441, "ATH.ENA (ATH)", "OASA", true},
     {0x31594F, "Oyster (LHR)", "TfL", true},
+    {0x4012F2, "Connect (SMF)", "SACOG", true},
     {0x422201, "Istanbulkart (IST)", "BELBIM", true},
     {0x422202, "Istanbulkart (IST)", "BELBIM", true},
     {0x422206, "Istanbulkart (IST)", "BELBIM", true},

--- a/scenes/metroflip_scene_credits.c
+++ b/scenes/metroflip_scene_credits.c
@@ -16,22 +16,22 @@ void metroflip_scene_credits_on_enter(void* context) {
     furi_string_printf(str, "\e#Credits:\n\n");
     furi_string_cat_printf(str, "Created by luu176\n");
     furi_string_cat_printf(str, "Inspired by Metrodroid\n\n");
-    furi_string_cat_printf(str, "Special Thanks:\n WillyJL\n\n");
-    furi_string_cat_printf(str, "Info Slaves:\n equipter, TheDingo8MyBaby\n ry4000, WillyJL\n");
+    furi_string_cat_printf(str, "Special Thanks:\nWillyJL\n\n");
+    furi_string_cat_printf(str, "Info Slaves:\nequipter, TheDingo8MyBaby\nry4000, WillyJL\n\n");
     furi_string_cat_printf(str, "\e#Parser Credits:\n\n");
-    furi_string_cat_printf(str, "Bip! Parser:\n rbasoalto, gornekich\n\n");
-    furi_string_cat_printf(str, "CharlieCard Parser:\n zacharyweiss\n\n");
-    furi_string_cat_printf(str, "Clipper Parser:\n ke6jjj\n\n");
-    furi_string_cat_printf(str, "ITSO Parser:\n gsp8181, hedger, gornekich\n\n");
-    furi_string_cat_printf(str, "Metromoney Parser:\n Leptopt1los\n\n");
-    furi_string_cat_printf(str, "myki Parser:\n gornekich\n\n");
-    furi_string_cat_printf(str, "Navigo Parser: \n luu176, DocSystem \n\n");
-    furi_string_cat_printf(str, "Opal Parser:\n gornekich\n\n");
-    furi_string_cat_printf(str, "Opus Parser:\n DocSystem\n\n");
-    furi_string_cat_printf(str, "Rav-Kav Parser:\n luu176\n\n");
-    furi_string_cat_printf(str, "RENFE Parser:\n BocamoCM\n\n");
-    furi_string_cat_printf(str, "Japan Transit IC Parser:\n zinongli\n\n");
-    furi_string_cat_printf(str, "Troika Parser:\n gornekich\n\n");
+    furi_string_cat_printf(str, "Bip! Parser:\nrbasoalto, gornekich\n\n");
+    furi_string_cat_printf(str, "CharlieCard Parser:\nzacharyweiss\n\n");
+    furi_string_cat_printf(str, "Clipper Parser:\nke6jjj\n\n");
+    furi_string_cat_printf(str, "ITSO Parser:\ngsp8181, hedger, gornekich\n\n");
+    furi_string_cat_printf(str, "Metromoney Parser:\nLeptopt1los\n\n");
+    furi_string_cat_printf(str, "myki Parser:\ngornekich\n\n");
+    furi_string_cat_printf(str, "Navigo Parser:\nluu176, DocSystem \n\n");
+    furi_string_cat_printf(str, "Opal Parser:\ngornekich\n\n");
+    furi_string_cat_printf(str, "Opus Parser:\nDocSystem\n\n");
+    furi_string_cat_printf(str, "Rav-Kav Parser:\nluu176\n\n");
+    furi_string_cat_printf(str, "RENFE Parser:\nBocamoCM\n\n");
+    furi_string_cat_printf(str, "Japan Transit IC Parser:\nzinongli\n\n");
+    furi_string_cat_printf(str, "Troika Parser:\ngornekich");
 
     widget_add_text_scroll_element(widget, 0, 0, 128, 64, furi_string_get_cstr(str));
 

--- a/scenes/metroflip_scene_credits.c
+++ b/scenes/metroflip_scene_credits.c
@@ -16,8 +16,8 @@ void metroflip_scene_credits_on_enter(void* context) {
     furi_string_printf(str, "\e#Credits:\n\n");
     furi_string_cat_printf(str, "Created by luu176\n");
     furi_string_cat_printf(str, "Inspired by Metrodroid\n\n");
-    furi_string_cat_printf(str, "Special Thanks:\n willyjl\n");
-    furi_string_cat_printf(str, "Info Slaves:\n Equip, TheDingo8MyBaby\n ry4000, WillyJL\n");
+    furi_string_cat_printf(str, "Special Thanks:\n WillyJL\n\n");
+    furi_string_cat_printf(str, "Info Slaves:\n equipter, TheDingo8MyBaby\n ry4000, WillyJL\n");
     furi_string_cat_printf(str, "\e#Parser Credits:\n\n");
     furi_string_cat_printf(str, "Bip! Parser:\n rbasoalto, gornekich\n\n");
     furi_string_cat_printf(str, "CharlieCard Parser:\n zacharyweiss\n\n");
@@ -27,10 +27,10 @@ void metroflip_scene_credits_on_enter(void* context) {
     furi_string_cat_printf(str, "myki Parser:\n gornekich\n\n");
     furi_string_cat_printf(str, "Navigo Parser: \n luu176, DocSystem \n\n");
     furi_string_cat_printf(str, "Opal Parser:\n gornekich\n\n");
-    furi_string_cat_printf(str, "Opus Parser: DocSystem\n\n");
-    furi_string_cat_printf(str, "Rav-Kav Parser: luu176\n\n");
-    furi_string_cat_printf(str, "Rav-Kav Parser: BocamoCM\n\n");
-    furi_string_cat_printf(str, "Japan Rail IC Parser:\n zinongli\n\n");
+    furi_string_cat_printf(str, "Opus Parser:\n DocSystem\n\n");
+    furi_string_cat_printf(str, "Rav-Kav Parser:\n luu176\n\n");
+    furi_string_cat_printf(str, "RENFE Parser:\n BocamoCM\n\n");
+    furi_string_cat_printf(str, "Japan Transit IC Parser:\n zinongli\n\n");
     furi_string_cat_printf(str, "Troika Parser:\n gornekich\n\n");
 
     widget_add_text_scroll_element(widget, 0, 0, 128, 64, furi_string_get_cstr(str));

--- a/scenes/metroflip_scene_load.c
+++ b/scenes/metroflip_scene_load.c
@@ -108,7 +108,7 @@ void metroflip_scene_load_on_enter(void* context) {
             } else {
                 const char* card_str = furi_string_get_cstr(card_type_str);
                 
-                if(strcmp(card_str, "Japan Rail IC") == 0) {
+                if(strcmp(card_str, "Japan Transit IC") == 0) {
                     app->card_type = "suica";
                     app->is_desfire = false;
                     app->data_loaded = true;
@@ -191,3 +191,4 @@ void metroflip_scene_load_on_exit(void* context) {
     Metroflip* app = context;
     UNUSED(app);
 }
+

--- a/scenes/metroflip_scene_save_result.c
+++ b/scenes/metroflip_scene_save_result.c
@@ -37,7 +37,7 @@ void metroflip_scene_save_result_on_enter(void* context) {
         success = flipper_format_file_open_new(ff, path);
         success &= flipper_format_write_header_cstr(ff, "Flipper Metroflip File", 1);
         success &= flipper_format_write_string_cstr(ff, "Device Type", "Felica");
-        success &= flipper_format_write_string_cstr(ff, "Card Type", "Japan Rail IC");
+        success &= flipper_format_write_string_cstr(ff, "Card Type", "Japan Transit IC");
         success &= flipper_format_write_string(ff, "Travel Logs:", app->suica_file_data);
         flipper_format_file_close(ff);
         flipper_format_free(ff);

--- a/scenes/plugins/suica.c
+++ b/scenes/plugins/suica.c
@@ -341,7 +341,7 @@ static NfcCommand suica_poller_callback(NfcGenericEvent event, void* context) {
         if(stage == MetroflipPollerEventTypeStart) {
             nfc_device_set_data(
                 app->nfc_device, NfcProtocolFelica, nfc_poller_get_data(app->poller));
-            furi_string_printf(parsed_data, "\e#Japan Rail IC\n");
+            furi_string_printf(parsed_data, "\e#Japan Transit IC\n");
 
             // Authenticate with the card
             // Iterate through the two services
@@ -397,13 +397,13 @@ static NfcCommand suica_poller_callback(NfcGenericEvent event, void* context) {
             if(model->size == 1) { // Have to let the poller run once before knowing we failed
                 furi_string_printf(
                     parsed_data,
-                    "\e#Japan Rail IC\nSorry, no data found.\nPlease let the developers know and we will add support.");
+                    "\e#Japan Transit IC\nSorry, no data found.\nPlease let the developers know and we will add support.");
             }
 
             if(model->size == 1 && felica_data->pmm.data[1] != SUICA_IC_TYPE_CODE) {
                 furi_string_printf(
                     parsed_data,
-                    "\e#Felica\nSorry, unrecorded IC type.\nIs this Octopus?\nPlease let the developers know and we will add support.");
+                    "\e#FeliCa\nSorry, unrecorded IC type.\nPlease let the developers know and we will add support.");
             }
             widget_add_text_scroll_element(
                 widget, 0, 0, 128, 64, furi_string_get_cstr(parsed_data));
@@ -544,7 +544,7 @@ static void suica_on_enter(Metroflip* app) {
         suica_model_initialize_after_load(model);
         Widget* widget = app->widget;
         FuriString* parsed_data = furi_string_alloc();
-        furi_string_printf(parsed_data, "\e#Japan Rail IC\n");
+        furi_string_printf(parsed_data, "\e#Japan Transit IC\n");
 
         for(uint8_t i = 0; i < model->size; i++) {
             furi_string_cat_printf(app->suica_file_data, "Log %02X: ", i);


### PR DESCRIPTION
1. `Japan Rail IC` changed to `Japan Transit IC` to better reflect Japan's multi-modal transit network.
2. `Felica` changed to `FeliCa`.
3. Removed references to `HKG Octopus` because we now know that `OCTOPUS_IC_TYPE_CODE` is `0x44` and `0x3B` per PTDex.

As a result of a supplemental commit:

4. Updated `myki` company from `myki (MEL)` to `TV` (Transport Victoria).
5. Added `Connect (SMF)` to as a locked AID `0x4012F2` to `desfire.c`.