### PR TITLE
NFC file version: align with firmware's current version number

### DIFF
--- a/metroflip_i.h
+++ b/metroflip_i.h
@@ -45,6 +45,7 @@
 #include <loader/firmware_api/firmware_api.h>
 #include <applications/services/storage/storage.h>
 #include <applications/services/dialogs/dialogs.h>
+#include <lib/nfc/nfc_common.h>
 
 #include "scenes/metroflip_scene.h"
 

--- a/scenes/plugins/bip.c
+++ b/scenes/plugins/bip.c
@@ -344,7 +344,7 @@ static void bip_on_enter(Metroflip* app) {
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         if(flipper_format_file_open_existing(ff, app->file_path)) {
             MfClassicData* mfc_data = mf_classic_alloc();
-            mf_classic_load(mfc_data, ff, 2);
+            mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
             FuriString* parsed_data = furi_string_alloc();
             Widget* widget = app->widget;
 

--- a/scenes/plugins/charliecard.c
+++ b/scenes/plugins/charliecard.c
@@ -1260,7 +1260,7 @@ static void charliecard_on_enter(Metroflip* app) {
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         if(flipper_format_file_open_existing(ff, app->file_path)) {
             MfClassicData* mfc_data = mf_classic_alloc();
-            mf_classic_load(mfc_data, ff, 2);
+            mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
             FuriString* parsed_data = furi_string_alloc();
             Widget* widget = app->widget;
 

--- a/scenes/plugins/clipper.c
+++ b/scenes/plugins/clipper.c
@@ -610,7 +610,7 @@ static void clipper_on_enter(Metroflip* app) {
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         if(flipper_format_file_open_existing(ff, app->file_path)) {
             MfDesfireData* data = mf_desfire_alloc();
-            mf_desfire_load(data, ff, 2);
+            mf_desfire_load(data, ff, NFC_CURRENT_FORMAT_VERSION);
             FuriString* parsed_data = furi_string_alloc();
             Widget* widget = app->widget;
 

--- a/scenes/plugins/gocard.c
+++ b/scenes/plugins/gocard.c
@@ -200,7 +200,7 @@ static void gocard_on_enter(Metroflip* app) {
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         if(flipper_format_file_open_existing(ff, app->file_path)) {
             MfClassicData* mfc_data = mf_classic_alloc();
-            mf_classic_load(mfc_data, ff, 2);
+            mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
             FuriString* parsed_data = furi_string_alloc();
             Widget* widget = app->widget;
 

--- a/scenes/plugins/itso.c
+++ b/scenes/plugins/itso.c
@@ -156,7 +156,7 @@ static void itso_on_enter(Metroflip* app) {
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         if(flipper_format_file_open_existing(ff, app->file_path)) {
             MfDesfireData* data = mf_desfire_alloc();
-            mf_desfire_load(data, ff, 2);
+            mf_desfire_load(data, ff, NFC_CURRENT_FORMAT_VERSION);
             FuriString* parsed_data = furi_string_alloc();
             Widget* widget = app->widget;
 

--- a/scenes/plugins/metromoney.c
+++ b/scenes/plugins/metromoney.c
@@ -150,7 +150,7 @@ static void metromoney_on_enter(Metroflip* app) {
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         if(flipper_format_file_open_existing(ff, app->file_path)) {
             MfClassicData* mfc_data = mf_classic_alloc();
-            mf_classic_load(mfc_data, ff, 2);
+            mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
             FuriString* parsed_data = furi_string_alloc();
             Widget* widget = app->widget;
 

--- a/scenes/plugins/myki.c
+++ b/scenes/plugins/myki.c
@@ -139,7 +139,7 @@ static void myki_on_enter(Metroflip* app) {
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         if(flipper_format_file_open_existing(ff, app->file_path)) {
             MfDesfireData* data = mf_desfire_alloc();
-            mf_desfire_load(data, ff, 2);
+            mf_desfire_load(data, ff, NFC_CURRENT_FORMAT_VERSION);
             FuriString* parsed_data = furi_string_alloc();
             Widget* widget = app->widget;
 

--- a/scenes/plugins/opal.c
+++ b/scenes/plugins/opal.c
@@ -258,7 +258,7 @@ static void opal_on_enter(Metroflip* app) {
         Storage* storage = furi_record_open(RECORD_STORAGE);
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         if(flipper_format_file_open_existing(ff, app->file_path)) {
-            mf_desfire_load(app->mfdes_data, ff, 2);
+            mf_desfire_load(app->mfdes_data, ff, NFC_CURRENT_FORMAT_VERSION);
             FuriString* parsed_data = furi_string_alloc();
             Widget* widget = app->widget;
 

--- a/scenes/plugins/renfe_regular.c
+++ b/scenes/plugins/renfe_regular.c
@@ -1145,7 +1145,7 @@ static void renfe_regular_on_enter(Metroflip* app) {
             FlipperFormat* ff = flipper_format_file_alloc(storage);
             if(flipper_format_file_open_existing(ff, app->file_path)) {
                 mfc_data = mf_classic_alloc();
-                mf_classic_load(mfc_data, ff, 2);
+                mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
                 should_free_mfc_data = true;
             }
             flipper_format_free(ff);
@@ -1252,7 +1252,7 @@ static bool renfe_regular_on_event(Metroflip* app, SceneManagerEvent event) {
                     FlipperFormat* ff = flipper_format_file_alloc(storage);
                     if(flipper_format_file_open_existing(ff, app->file_path)) {
                         mfc_data = mf_classic_alloc();
-                        mf_classic_load(mfc_data, ff, 2);
+                        mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
                         should_free_mfc_data = true;
                     }
                     flipper_format_free(ff);
@@ -1291,7 +1291,7 @@ static bool renfe_regular_on_event(Metroflip* app, SceneManagerEvent event) {
                     FlipperFormat* ff = flipper_format_file_alloc(storage);
                     if(flipper_format_file_open_existing(ff, app->file_path)) {
                         mfc_data = mf_classic_alloc();
-                        mf_classic_load(mfc_data, ff, 2);
+                        mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
                         should_free_mfc_data = true;
                     }
                     flipper_format_free(ff);

--- a/scenes/plugins/renfe_sum10.c
+++ b/scenes/plugins/renfe_sum10.c
@@ -1430,7 +1430,7 @@ static void renfe_sum10_on_enter(Metroflip* app) {
             FlipperFormat* ff = flipper_format_file_alloc(storage);
             if(flipper_format_file_open_existing(ff, app->file_path)) {
                 mfc_data = mf_classic_alloc();
-                mf_classic_load(mfc_data, ff, 2);
+                mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
                 should_free_mfc_data = true;
             }
             flipper_format_free(ff);
@@ -1549,7 +1549,7 @@ static bool renfe_sum10_on_event(Metroflip* app, SceneManagerEvent event) {
                     FlipperFormat* ff = flipper_format_file_alloc(storage);
                     if(flipper_format_file_open_existing(ff, app->file_path)) {
                         mfc_data = mf_classic_alloc();
-                        mf_classic_load(mfc_data, ff, 2);
+                        mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
                         should_free_mfc_data = true;
                     }
                     flipper_format_free(ff);
@@ -1611,7 +1611,7 @@ static bool renfe_sum10_on_event(Metroflip* app, SceneManagerEvent event) {
                     FlipperFormat* ff = flipper_format_file_alloc(storage);
                     if(flipper_format_file_open_existing(ff, app->file_path)) {
                         mfc_data = mf_classic_alloc();
-                        mf_classic_load(mfc_data, ff, 2);
+                        mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
                         should_free_mfc_data = true;
                     }
                     flipper_format_free(ff);

--- a/scenes/plugins/smartrider.c
+++ b/scenes/plugins/smartrider.c
@@ -342,7 +342,7 @@ static void smartrider_on_enter(Metroflip* app) {
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         if(flipper_format_file_open_existing(ff, app->file_path)) {
             MfClassicData* mfc_data = mf_classic_alloc();
-            mf_classic_load(mfc_data, ff, 2);
+            mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
             FuriString* parsed_data = furi_string_alloc();
             Widget* widget = app->widget;
 

--- a/scenes/plugins/troika.c
+++ b/scenes/plugins/troika.c
@@ -1562,7 +1562,7 @@ static void troika_on_enter(Metroflip* app) {
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         if(flipper_format_file_open_existing(ff, app->file_path)) {
             MfClassicData* mfc_data = mf_classic_alloc();
-            mf_classic_load(mfc_data, ff, 2);
+            mf_classic_load(mfc_data, ff, NFC_CURRENT_FORMAT_VERSION);
             FuriString* parsed_data = furi_string_alloc();
             Widget* widget = app->widget;
 


### PR DESCRIPTION
Include firmware's `nfc_common.h` and use `NFC_CURRENT_FORMAT_VERSION` macro when loading data, instead of hardcoded version numbers