### PR TITLE
New Parser: nol (DXB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ This is a list of metro cards and transit systems that need support or have part
 | **Suica**          | 🇯🇵 Japan                                     | FeliCa            |
 | **Troika**         | 🇷🇺 Moscow, Russia                            | MIFARE Classic    |
 | **Octopus**        | 🇭🇰 Hong Kong                                 | FeliCa            |
+| **nol**            | 🇦🇪 Dubai, UAE                                | MIFARE DESFire    |
+
 
 
 ---
@@ -105,6 +107,7 @@ This is a list of metro cards and transit systems that need support or have part
 - **Suica Parser:** [@zinongli](https://github.com/zinongli)
 - **Troika Parser:** [@gornekich](https://github.com/gornekich)
 - **Octopus Parser:** [@zinongli](https://github.com/zinongli)
+- **nol Parser:** [@zinongli](https://github.com/zinongli)
 
 ---
 

--- a/application.fam
+++ b/application.fam
@@ -138,3 +138,12 @@ App(
     sources=["scenes/plugins/renfe_regular.c"],
     fal_embedded=True,
 )
+
+App(
+    appid="nol_plugin",
+    apptype=FlipperAppType.PLUGIN,
+    entry_point="nol_plugin_ep",
+    requires=["metroflip"],
+    sources=["scenes/plugins/nol.c"],
+    fal_embedded=True,
+)

--- a/scenes/desfire.c
+++ b/scenes/desfire.c
@@ -26,7 +26,7 @@ TransitCardInfo cards[82] = {
     {0x004048, "Mi Movilidad (GDL)", "SITEUR", true},
     {0x004055, "AT HOP (AKL)", "Auckland Transport", true},
     {0x004063, "Travel Pass (DOH)", "Qatar Rail", true},
-    {0x004078, "nol (DXB)", "RTA", true},
+    {0x004078, "nol", "RTA", false},
     {0x008057, "NORTIC", "NRPA", true},
     {0x010000, "Breeze / Compass / EASY / FREEDOM", "MARTA / TransLink / MIA County / PATCO", true},
     {0x012340, "motion (ECN)", "MoTCW", true},

--- a/scenes/metroflip_scene_credits.c
+++ b/scenes/metroflip_scene_credits.c
@@ -33,6 +33,7 @@ void metroflip_scene_credits_on_enter(void* context) {
     furi_string_cat_printf(str, "Japan Transit IC Parser:\nzinongli\n\n");
     furi_string_cat_printf(str, "Troika Parser:\ngornekich");
     furi_string_cat_printf(str, "Octopus Parser:\nzinongli\n\n");
+    furi_string_cat_printf(str, "nol Parser:\nzinongli\n\n");
 
     widget_add_text_scroll_element(widget, 0, 0, 128, 64, furi_string_get_cstr(str));
 

--- a/scenes/metroflip_scene_save_result.c
+++ b/scenes/metroflip_scene_save_result.c
@@ -37,7 +37,6 @@ void metroflip_scene_save_result_on_enter(void* context) {
         FlipperFormat* ff = flipper_format_file_alloc(storage);
         flipper_format_write_empty_line(ff);
         flipper_format_file_open_existing(ff, path);
-        flipper_format_insert_or_update_string_cstr(ff, "Card Type", app->card_type);
         flipper_format_file_close(ff);
         flipper_format_free(ff);
         furi_record_close(RECORD_STORAGE);

--- a/scenes/plugins/nol.c
+++ b/scenes/plugins/nol.c
@@ -1,0 +1,196 @@
+#include <flipper_application.h>
+
+#include <lib/nfc/protocols/mf_desfire/mf_desfire.h>
+#include <stdio.h>
+#include <lib/bit_lib/bit_lib.h>
+
+#include "../../metroflip_i.h"
+#include <nfc/protocols/mf_desfire/mf_desfire_poller.h>
+#include "../../api/metroflip/metroflip_api.h"
+#include "../../metroflip_plugins.h"
+
+#define TAG           "Metroflip:Scene:nol"
+#define NOL_FILE_SIZE 64
+
+static const MfDesfireApplicationId nol_app_id = {.data = {0xff, 0xff, 0xff}};
+static const MfDesfireFileId nol_file_id = 0x08;
+
+bool nol_parse(const MfDesfireData* data, FuriString* parsed_data) {
+    furi_assert(parsed_data);
+
+    bool parsed = false;
+
+    do {
+        const MfDesfireApplication* app = mf_desfire_get_application(data, &nol_app_id);
+        if(app == NULL) break;
+        // don't need to check aid 004078 again
+        // we wouldn't have ended up in this plugin if it wasn't found by desfire manager
+
+        const MfDesfireFileSettings* file_settings =
+            mf_desfire_get_file_settings(app, &nol_file_id);
+
+        if(file_settings == NULL || file_settings->type != MfDesfireFileTypeStandard ||
+           file_settings->data.size < NOL_FILE_SIZE)
+            break;
+
+        const MfDesfireFileData* file_data = mf_desfire_get_file_data(app, &nol_file_id);
+        if(file_data == NULL) break;
+
+        uint8_t* nol_file = simple_array_get_data(file_data->data);
+        uint32_t nol_serial_number = bit_lib_get_bits_32(nol_file, 61, 32);
+
+        uint32_t first_group  = (nol_serial_number / 10000000U) % 1000U;  // top 3 digits
+        uint32_t middle_group = (nol_serial_number / 10000U)     % 1000U;  // next 3
+        uint32_t last_group   =  nol_serial_number               % 10000U; // last 4
+        
+        furi_string_set(parsed_data, "\e#nol\n\nSerial No.: ");
+        furi_string_cat_printf(parsed_data, "%03ld" "-%03ld" "-%04ld",
+                               first_group, middle_group, last_group);
+        parsed = true;
+    } while(false);
+
+    return parsed;
+}
+
+static NfcCommand nol_poller_callback(NfcGenericEvent event, void* context) {
+    furi_assert(event.protocol == NfcProtocolMfDesfire);
+
+    Metroflip* app = context;
+    NfcCommand command = NfcCommandContinue;
+
+    FuriString* parsed_data = furi_string_alloc();
+    Widget* widget = app->widget;
+    furi_string_reset(app->text_box_store);
+    const MfDesfirePollerEvent* mf_desfire_event = event.event_data;
+    if(mf_desfire_event->type == MfDesfirePollerEventTypeReadSuccess) {
+        nfc_device_set_data(
+            app->nfc_device, NfcProtocolMfDesfire, nfc_poller_get_data(app->poller));
+        const MfDesfireData* data = nfc_device_get_data(app->nfc_device, NfcProtocolMfDesfire);
+        if(!nol_parse(data, parsed_data)) {
+            furi_string_reset(app->text_box_store);
+            FURI_LOG_I(TAG, "Unknown card type");
+            furi_string_printf(parsed_data, "\e#Unknown card\n");
+        }
+        widget_add_text_scroll_element(widget, 0, 0, 128, 64, furi_string_get_cstr(parsed_data));
+
+        widget_add_button_element(
+            widget, GuiButtonTypeRight, "Exit", metroflip_exit_widget_callback, app);
+        widget_add_button_element(
+            widget, GuiButtonTypeCenter, "Save", metroflip_save_widget_callback, app);
+
+        furi_string_free(parsed_data);
+        view_dispatcher_switch_to_view(app->view_dispatcher, MetroflipViewWidget);
+        metroflip_app_blink_stop(app);
+        command = NfcCommandStop;
+    } else if(mf_desfire_event->type == MfDesfirePollerEventTypeReadFailed) {
+        view_dispatcher_send_custom_event(app->view_dispatcher, MetroflipCustomEventPollerSuccess);
+        command = NfcCommandContinue;
+    }
+
+    return command;
+}
+
+static void nol_on_enter(Metroflip* app) {
+    dolphin_deed(DolphinDeedNfcRead);
+
+    if(app->data_loaded) {
+        Storage* storage = furi_record_open(RECORD_STORAGE);
+        FlipperFormat* ff = flipper_format_file_alloc(storage);
+        if(flipper_format_file_open_existing(ff, app->file_path)) {
+            MfDesfireData* data = mf_desfire_alloc();
+            mf_desfire_load(data, ff, 2);
+            FuriString* parsed_data = furi_string_alloc();
+            Widget* widget = app->widget;
+
+            furi_string_reset(app->text_box_store);
+            if(!nol_parse(data, parsed_data)) {
+                furi_string_reset(app->text_box_store);
+                FURI_LOG_I(TAG, "Unknown card type");
+                furi_string_printf(parsed_data, "\e#Unknown card\n");
+            }
+            widget_add_text_scroll_element(
+                widget, 0, 0, 128, 64, furi_string_get_cstr(parsed_data));
+
+            widget_add_button_element(
+                widget, GuiButtonTypeRight, "Exit", metroflip_exit_widget_callback, app);
+            widget_add_button_element(
+                widget, GuiButtonTypeCenter, "Delete", metroflip_delete_widget_callback, app);
+            mf_desfire_free(data);
+            furi_string_free(parsed_data);
+            view_dispatcher_switch_to_view(app->view_dispatcher, MetroflipViewWidget);
+        }
+        flipper_format_free(ff);
+    } else {
+        // Setup view
+        Popup* popup = app->popup;
+        popup_set_header(popup, "Apply\n card to\nthe back", 68, 30, AlignLeft, AlignTop);
+        popup_set_icon(popup, 0, 3, &I_RFIDDolphinReceive_97x61);
+
+        // Start worker
+        view_dispatcher_switch_to_view(app->view_dispatcher, MetroflipViewPopup);
+        nfc_scanner_alloc(app->nfc);
+        app->poller = nfc_poller_alloc(app->nfc, NfcProtocolMfDesfire);
+        nfc_poller_start(app->poller, nol_poller_callback, app);
+
+        metroflip_app_blink_start(app);
+    }
+}
+
+static bool nol_on_event(Metroflip* app, SceneManagerEvent event) {
+    bool consumed = false;
+
+    if(event.type == SceneManagerEventTypeCustom) {
+        if(event.event == MetroflipCustomEventCardDetected) {
+            Popup* popup = app->popup;
+            popup_set_header(popup, "DON'T\nMOVE", 68, 30, AlignLeft, AlignTop);
+            consumed = true;
+        } else if(event.event == MetroflipCustomEventCardLost) {
+            Popup* popup = app->popup;
+            popup_set_header(popup, "Card \n lost", 68, 30, AlignLeft, AlignTop);
+            consumed = true;
+        } else if(event.event == MetroflipCustomEventWrongCard) {
+            Popup* popup = app->popup;
+            popup_set_header(popup, "WRONG \n CARD", 68, 30, AlignLeft, AlignTop);
+            consumed = true;
+        } else if(event.event == MetroflipCustomEventPollerFail) {
+            Popup* popup = app->popup;
+            popup_set_header(popup, "Failed", 68, 30, AlignLeft, AlignTop);
+            consumed = true;
+        }
+    } else if(event.type == SceneManagerEventTypeBack) {
+        scene_manager_search_and_switch_to_previous_scene(app->scene_manager, MetroflipSceneStart);
+        consumed = true;
+    }
+
+    return consumed;
+}
+
+static void nol_on_exit(Metroflip* app) {
+    widget_reset(app->widget);
+    metroflip_app_blink_stop(app);
+    if(app->poller && !app->data_loaded) {
+        nfc_poller_stop(app->poller);
+        nfc_poller_free(app->poller);
+    }
+}
+
+/* Actual implementation of app<>plugin interface */
+static const MetroflipPlugin nol_plugin = {
+    .card_name = "nol",
+    .plugin_on_enter = nol_on_enter,
+    .plugin_on_event = nol_on_event,
+    .plugin_on_exit = nol_on_exit,
+
+};
+
+/* Plugin descriptor to comply with basic plugin specification */
+static const FlipperAppPluginDescriptor nol_plugin_descriptor = {
+    .appid = METROFLIP_SUPPORTED_CARD_PLUGIN_APP_ID,
+    .ep_api_version = METROFLIP_SUPPORTED_CARD_PLUGIN_API_VERSION,
+    .entry_point = &nol_plugin,
+};
+
+/* Plugin entry point - must return a pointer to const descriptor  */
+const FlipperAppPluginDescriptor* nol_plugin_ep(void) {
+    return &nol_plugin_descriptor;
+}

--- a/scenes/plugins/nol.c
+++ b/scenes/plugins/nol.c
@@ -44,7 +44,7 @@ bool nol_parse(const MfDesfireData* data, FuriString* parsed_data) {
         uint32_t last_group   =  nol_serial_number               % 10000U; // last 4
         
         furi_string_set(parsed_data, "\e#nol\n\nSerial No.: ");
-        furi_string_cat_printf(parsed_data, "%03ld" "-%03ld" "-%04ld",
+        furi_string_cat_printf(parsed_data, "%03ld %03ld %04ld",
                                first_group, middle_group, last_group);
         parsed = true;
     } while(false);


### PR DESCRIPTION
Parse the serial number of the card. Everything else is encrypted so this is the best we can do. 

On the side note, Metrodroid claims to be able to [read card type](https://github.com/metrodroid/metrodroid/blob/2b42560235250ae04135698f2b18eed67ad6ef71/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/serialonly/NolTransitData.kt#L42-L43). Its code assigns `0x4d5` to regular / silver card and `0x4d9` to day pass / red card. But my regular card has `0x600`?! So without more data, I don't think we should add it now. If we confirm how it works we can add it later. 

[Nol.txt](https://github.com/user-attachments/files/22702818/Nol.txt)

<img width="512" height="256" alt="Screenshot-20251004-201905" src="https://github.com/user-attachments/assets/c64f8a39-1904-41e3-9c13-3c3e92c34b3d" />
