### PR TITLE
Fix compilation issue caused by malformed application.fam

### DIFF
--- a/application.fam
+++ b/application.fam
@@ -145,6 +145,9 @@ App(
     entry_point="tmoney_plugin_ep",
     requires=["metroflip"],
     sources=["scenes/plugins/tmoney.c"],
+)
+
+App(
     appid="renfe_regular_plugin",
     apptype=FlipperAppType.PLUGIN,
     entry_point="renfe_regular_plugin_ep",


### PR DESCRIPTION
Fixed syntax error in application.fam introduced by pull request #77 commit c01ff3a that causes compilation to fail.